### PR TITLE
Changed FormData to FormData-node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 node_modules
+yarn.lock

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-import fs from 'fs/promises'
 import fetch from 'node-fetch'
 import {FormData, Blob} from "formdata-node"
 import {fileFromPath} from "formdata-node/file-from-path"

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import fs from 'fs/promises'
 import fetch from 'node-fetch'
-import FormData from 'form-data'
+import {FormData, Blob} from "formdata-node"
+import {fileFromPath} from "formdata-node/file-from-path"
 import path from 'path'
 import _ from 'lodash'
 import generateBasicAuth from 'basic-authorization-header'
@@ -73,7 +74,7 @@ async function uploadMediaFile(mediafile, token, userAgent) {
   let file, mimetype, filename
 
   if (typeof mediafile === 'string') {
-    file = await fs.readFile(mediafile)
+    file = await fileFromPath(mediafile)
     filename = path.basename(mediafile)
     mimetype = guessMimeType(filename)
   //} else if (file instanceof Buffer) {
@@ -92,12 +93,12 @@ async function uploadMediaFile(mediafile, token, userAgent) {
 function guessMimeType(filename) {
   const extension = path.extname(filename)
   const mimeTypes = {
-    'png': 'image/png',
-    'mov': 'video/quicktime',
-    'mp4': 'video/mp4',
-    'jpg': 'image/jpeg',
-    'jpeg': 'image/jpeg',
-    'gif': 'image/gif',
+    '.png': 'image/png',
+    '.mov': 'video/quicktime',
+    '.mp4': 'video/mp4',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.gif': 'image/gif',
   }
   return mimeTypes[extension] ?? mimeTypes.jpeg
 }

--- a/package.json
+++ b/package.json
@@ -7,13 +7,18 @@
   "scripts": {
     "test": "node test.js"
   },
-  "keywords": ["reddit","api","reddit-api","reddit-api-wrappe"],
+  "keywords": [
+    "reddit",
+    "api",
+    "reddit-api",
+    "reddit-api-wrappe"
+  ],
   "author": "vityaschel <hi@hloth.dev> (https://hloth.dev/)",
   "license": "MIT",
   "dependencies": {
     "basic-authorization-header": "^0.2.7",
     "fast-xml-parser": "^4.0.7",
-    "form-data": "^4.0.0",
+    "formdata-node": "^4.3.2",
     "lodash": "^4.17.21",
     "node-fetch": "^3.2.3"
   },


### PR DESCRIPTION
`FormData` is no longer suppeorted, more info in [this issue](https://github.com/node-fetch/node-fetch/issues/1167). 
Following the discussion, I changed it to `FormData-node` and the function used to import the file.

While working on that, I also discovered, that the `guessMimeType` was returning the wrong type because of a mismatch between  `const extension = path.extname(filename)` and the list of `mimeTypes`

